### PR TITLE
A request queue that understands "metering"

### DIFF
--- a/ENAPILibrary/ENAPILibrary/ENAPI.m
+++ b/ENAPILibrary/ENAPILibrary/ENAPI.m
@@ -140,7 +140,7 @@ NSString *ENEscapeStringForURL (NSString *str) {
     unsigned char md5Buffer[CC_MD5_DIGEST_LENGTH];
     
     // Create 16 byte MD5 hash value, store in buffer
-    CC_MD5(data.bytes, data.length, md5Buffer);
+    CC_MD5(data.bytes, (CC_LONG) data.length, md5Buffer);
     
     // Convert unsigned char buffer to NSString of hex values
     NSMutableString *output = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];

--- a/ENAPILibrary/ENAPILibrary/ENAPIRequest.h
+++ b/ENAPILibrary/ENAPILibrary/ENAPIRequest.h
@@ -132,6 +132,11 @@ static NSString __attribute__((unused)) * const ECHONEST_API_URL = @"http://deve
 @property (readonly) NSInteger httpResponseCode;
 
 /**
+ * The HTTP headers with this response.
+ */
+@property (readonly) NSDictionary *httpResponseHeaders;
+
+/**
  * The Echo Nest status code, 0 is a successful status.  [Echo Nest response code list.](http://developer.echonest.com/docs/v4/index.html#response-codes)
  */
 @property (readonly) NSInteger echonestStatusCode;

--- a/ENAPILibrary/ENAPILibrary/ENAPIRequest.m
+++ b/ENAPILibrary/ENAPILibrary/ENAPIRequest.m
@@ -117,7 +117,7 @@ static NSMutableArray *EN_SECURED_ENDPOINTS = nil;
 }
 
 - (NSString *)generateNonce:(NSInteger)timestamp {
-    NSString *tmp = [[NSString alloc] initWithFormat:@"%d", timestamp];
+    NSString *tmp = [[NSNumber numberWithInteger:timestamp] stringValue];
     NSData *nonceData = [tmp dataUsingEncoding:NSUTF8StringEncoding];
     NSString *nonce = [ENAPI calculateMD5DigestFromData:nonceData];
     return nonce;
@@ -218,7 +218,7 @@ static NSMutableArray *EN_SECURED_ENDPOINTS = nil;
     [body appendData:[[NSString stringWithFormat:@"--\r\n"] dataUsingEncoding:NSUTF8StringEncoding]];
     
     if (body != nil) {
-        [request setValue:[NSString stringWithFormat:@"%d", [body length]] forHTTPHeaderField:@"Content-Length"];
+        [request setValue:[[NSNumber numberWithUnsignedInteger:[body length]] stringValue] forHTTPHeaderField:@"Content-Length"];
         [request setHTTPBody:body];
     } else {
         NSLog(@"ENAPIRequest: post body is nil");

--- a/ENAPILibrary/ENAPILibrary/ENAPIRequest.m
+++ b/ENAPILibrary/ENAPILibrary/ENAPIRequest.m
@@ -340,6 +340,10 @@ static NSMutableArray *EN_SECURED_ENDPOINTS = nil;
     return self.urlResponse.statusCode;
 }
 
+- (NSDictionary *)httpResponseHeaders {
+    return [self.urlResponse allHeaderFields];
+}
+
 - (NSInteger)echonestStatusCode {
     if (self.response == nil) {
         return -1;
@@ -410,31 +414,10 @@ static NSMutableArray *EN_SECURED_ENDPOINTS = nil;
 }
 
 #pragma NSURLConnectionDelegate
-- (BOOL)connection:(NSURLConnection *)connection canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace {
-    NSLog(@"ENAPIRequest: unexpected canAuthenticateAgainstProtectionSpace");
-    return YES;
-}
-
-- (void)connection:(NSURLConnection *)connection didCancelAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
-    NSLog(@"ENAPIRequest: unexpected didCancelAuthenticationChallenge");
-}
 
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
     self.error = error;
     [self executeCompletionBlock];
-}
-
-- (void)connection:(NSURLConnection *)connection didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
-    NSLog(@"ENAPIRequest: unexpected didReceiveAuthenticationChallenge");
-}
-
-- (void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
-    NSLog(@"ENAPIRequest: unexpected willSendRequestForAuthenticationChallenge");
-}
-
-- (BOOL)connectionShouldUseCredentialStorage:(NSURLConnection *)connection {
-    NSLog(@"ENAPIRequest: unexpected connectionShouldUseCredentialStorage");
-    return YES;
 }
 
 @end

--- a/ENAPILibrary/ENAPILibrary/ENAPIRequestQueue.h
+++ b/ENAPILibrary/ENAPILibrary/ENAPIRequestQueue.h
@@ -1,0 +1,48 @@
+//
+//  ENAPIRequestQueue.h
+//  ENAPILibrary
+//
+//  Created by Andrew Goodale (andrew@seaviewsoftware.com)
+//  Copyright (c) 2014, Echo Nest Corporation
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//   * Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of the tapsquare, llc nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL TAPSQUARE, LLC. BE LIABLE FOR ANY
+//  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+#import "ENAPIRequest.h"
+
+/**
+ * This class implements a serial queue to manage multiple ENAPI requests with the API rate limits.
+ * Requests are queued and executed within the constraints of the rate limits for the API Key being used. When the limit is reached, the queue will block further requests for one minute, to let the limit refresh.
+ */
+@interface ENAPIRequestQueue : NSObject
+
+/**
+ * Like the ENAPIRequest method, but puts the request on the queue.
+ */
+- (void)GETWithEndpoint:(NSString *)endpoint
+          andParameters:(NSDictionary *)parameters
+     andCompletionBlock:(ENAPIRequestCompletionBlock)completionBlock;
+
+@end

--- a/ENAPILibrary/ENAPILibrary/ENAPIRequestQueue.m
+++ b/ENAPILibrary/ENAPILibrary/ENAPIRequestQueue.m
@@ -1,0 +1,93 @@
+//
+//  ENAPIRequestQueue.m
+//  ENAPILibrary
+//
+//  Created by Andrew Goodale (andrew@seaviewsoftware.com)
+//  Copyright (c) 2014, Echo Nest Corporation
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//   * Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of the tapsquare, llc nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL TAPSQUARE, LLC. BE LIABLE FOR ANY
+//  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import "ENAPIRequestQueue.h"
+#import "ENAPIRequest.h"
+
+const long kMaxSimultaneousRequests = 4;
+
+static NSString *const kHeaderLimit = @"X-RateLimit-Limit";             // the current rate limit for this API key
+static NSString *const kHeaderLimitUsed = @"X-RateLimit-Used";          // the number of method calls used on this API key this minute
+static NSString *const kHeaderLimitRemaining= @"X-RateLimit-Remaining"; // the estimated number of remaining calls allowed by this API key this minute
+
+
+@implementation ENAPIRequestQueue
+{
+    dispatch_queue_t     _requestQueue;
+    dispatch_semaphore_t _netSemaphore;
+}
+
+- (instancetype)init
+{
+    if ((self = [super init])) {
+        _requestQueue = dispatch_queue_create("ENAPIRequestQueue", DISPATCH_QUEUE_SERIAL);
+        _netSemaphore = dispatch_semaphore_create(kMaxSimultaneousRequests);
+    }
+    
+    return self;
+}
+
+- (void)GETWithEndpoint:(NSString *)endpoint
+          andParameters:(NSDictionary *)parameters
+     andCompletionBlock:(ENAPIRequestCompletionBlock)completionBlock
+{
+    dispatch_semaphore_t netSemaphore = _netSemaphore;
+    
+    dispatch_async(_requestQueue, ^{
+        // Wait for the semaphore to get our access to the network
+        dispatch_semaphore_wait(netSemaphore, DISPATCH_TIME_FOREVER);
+        
+        // Initiate the request on the main thread, because NSURLConnection prefers that
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [ENAPIRequest GETWithEndpoint:endpoint andParameters:parameters andCompletionBlock:^(ENAPIRequest *request) {
+                NSDictionary *headers = request.httpResponseHeaders;
+                NSString *limitRemaining = [headers objectForKey:kHeaderLimitRemaining];
+#if DEBUG
+                NSLog(@"ENAPIRequestQueue: Limit Used %@, Remaining %@", [headers objectForKey:kHeaderLimitUsed], limitRemaining);
+#endif
+                // If the API limit is being reached, don't signal the semaphore for a minute. That will block tasks until the
+                // remaining limit goes back up
+                if ([limitRemaining intValue] < kMaxSimultaneousRequests) {
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                        dispatch_semaphore_signal(netSemaphore);
+                    });
+                } else {
+                    dispatch_semaphore_signal(netSemaphore);
+                }
+                
+                // Call the completion block after we signal the semaphore since this block may take time to finish.
+                completionBlock(request);
+            }];
+        });
+    });
+}
+
+@end


### PR DESCRIPTION
This pull request introduces an `ENAPIRequestQueue` class which can be used to queue up multiple API requests and make sure they are executed within the developer's API rate limit. The queue exposes the same API for making GET requests as `ENAPIRequest`. Calling the method will add the request to the queue. When a response comes back, the queue looks at the rate limit headers and detects when the API limit has been reached. The queue then waits a minute until the limit resets back to zero and starts making requests again. The queue also has limits the number of simultaneous requests to prevent the application from using too many connections at once.
